### PR TITLE
Fixing thing that breaks basic instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,8 @@ services:
   database:
     image: mysql:5.7
     container_name: db
-    # ports:
-      # - "3306:3306"
+    ports:
+      - "3306:3306"
     env_file:
       - env/database.env
 
@@ -15,9 +15,9 @@ services:
     container_name: powerdns
     links:
       - database:db
-    # ports:
-      # - "53:53/tcp"
-      # - "53:53/udp"
+    ports:
+      - "53:53/tcp"
+      - "53:53/udp"
       - "8081:8081"
     entrypoint: /start.sh
     env_file:


### PR DESCRIPTION
The instructions say
Clone the repo and run
`docker-compose build`
`docker-compose up`
and then it should be ready to connect to. Instead it panics because someone commented the port entry out.

This pull uncomments those lines out so the instructions will work as expected.